### PR TITLE
Player의 HP 업데이트 부문 수정

### DIFF
--- a/unit_controller.gd
+++ b/unit_controller.gd
@@ -76,8 +76,8 @@ func _on_player_attacked(player: Unit, damage: int) -> void:
 		log_append.emit("Player attacked %d damage to -> %s" % [damage, str(e_name)])
 
 func _on_unit_attacked(unit:Unit, damage: int) -> void:
-	if player.hp != 0 and not player.is_dead:
-		player.hp -= damage
+	if player.hp > 0 and not player.is_dead:
+		player.hp = clamp(0, player.hp - damage, player.max_hp)
 		log_append.emit("%s attacked Player! damaged: %d" % [str(unit.name), damage])
 		player.player_health_changed.emit(player.hp)
 


### PR DESCRIPTION
* 통상적으로 hp != 0이겠지만, 추가적 상황 방어를 위해 0 초과시에만 계산하도록 수정 
* hp의 최대 및 최소값을 정하고 범위 내에서 조정 되도록 수정